### PR TITLE
Make it possible to give an api key to the GiosgHttpApi when app installations don't exist

### DIFF
--- a/giosgapps_bindings/django/services.py
+++ b/giosgapps_bindings/django/services.py
@@ -10,15 +10,17 @@ class GiosgHttpApi:
     CHAT_HOST = os.environ.get('SERVICE_GIOSG_COM', 'https://service.giosg.com')
 
     def __init__(self, org_id, installation_model, api_key=None):
-        try:
-            conf = installation_model.objects.get(installed_org_uuid=org_id)
-        except ObjectDoesNotExist:
-            raise ValueError('Cannot instantiate Giosg API without persistent token. '
-                             'Either app has not been installed for this org, '
-                             'or the token was not saved on app install.')
-        self.auth_headers = {'Authorization': '{} {}'.format(conf.persistent_token_prefix, conf.persistent_bot_token)}
         if api_key:
             self.auth_headers = {'Authorization': '{} {}'.format("Token", api_key)}
+        else:
+            try:
+                conf = installation_model.objects.get(installed_org_uuid=org_id)
+            except ObjectDoesNotExist:
+                raise ValueError('Cannot instantiate Giosg API without persistent token. '
+                                'Either app has not been installed for this org, '
+                                'or the token was not saved on app install.')
+            self.auth_headers = {'Authorization': '{} {}'.format(conf.persistent_token_prefix, conf.persistent_bot_token)}
+            
 
     def get(self, endpoint, params={}, headers={}):
         try:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('requirements.txt') as f:
     setup(
       name='giosgapps_bindings',
       packages=setuptools.find_packages(),
-      version='0.1.0',
+      version='0.1.1',
       license='MIT',
       description='Module for Giosg Apps development',
       author='Giosg',


### PR DESCRIPTION
Currently if one wants to use a custom api key in the authentication for GiosgHttpApi, they had to provide the giosg app model and org id for the code to check that an app installation exists. However, the existence of an app installation doesn't affect how the authorization header is set using the api key.

This pull doesn't change the input parameters of the GiosgHttpApi constructor but skips the app installation check if api key is provided. This allows users to use the GiosgHttpApi for making api calls without any app installations.